### PR TITLE
Allow get_or_create_id to take anything we may call to_owned() acceptably on.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,16 @@ jobs:
       - name: Install grcov
         run: cargo install grcov
 
-      - name: Run clippy, fmt, coverage... using xtask
+      - name: Run clippy, fmt, ... using xtask
         run: cargo xtask ci
+
+      - name: Run test coverage
+        run: cargo xtask coverage
+
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v3
+        with:
+          files: coverage/*.lcov
 
   reuse-compliance:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,22 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ## Unreleased
 
+### Major changes
+
 - Relicense to "MIT or Apache-2.0" to match the rest of the Rust ecosystem.
-- Add reference to the docs.rs docs in Cargo.toml
-- Add tests to increase line coverage to 100%
-- Add more derived traits to `NonUniqueTransformOutputError` for the sake of the tests.
-- Remove leftover redundant assert.
-- Add some `#[must_use]`.
-- Improve docs.
+- Make the argument to `get_or_create_id` generic using `ToOwned` trait, for
+  easier argument passing, especially with strings.
+
+### Minor changes
+
 - Add "xtask" setup for easy running of test code coverage.
+- Add tests to increase line coverage to 100%
+- Add reference to the docs.rs docs in Cargo.toml
+- Add more derived traits to `NonUniqueTransformOutputError` for the sake of the
+  tests.
+- Add some `#[must_use]`.
+- Remove leftover redundant assert.
+- Improve docs.
 
 ## 1.0.0
 


### PR DESCRIPTION
Simplifies usage with strings and things like them.